### PR TITLE
Naming source on and adding hyperlink to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,7 +127,8 @@ input {
         </td>
       </tr>
     </table>
-    <p>Source: JHU</p>		
+    <p><b>Source</b>: Coronavirus (COVID-19) Global Cases by the Center for Systems Science and Engineering (CSSE) at Johns Hopkins University (JHU)</p>
+    <p><b>Hyperlink</b>: <a href="arcgis.com/apps/opsdashboard/index.html#/bda7594740fd40299423467b48e9ecf6">arcgis.com/apps/opsdashboard/index.html#/bda7594740fd40299423467b48e9ecf6</a></p>
     <script src="viz.js"></script>
 </div>
 


### PR DESCRIPTION
I've replaced "JHU" with "Coronavirus (COVID-19) Global Cases by the Center for Systems Science and Engineering (CSSE) at Johns Hopkins University (JHU)" to be more specific. I also provided the link to the ArcGIS Online widget: arcgis.com/apps/opsdashboard/index.html#/bda7594740fd40299423467b48e9ecf6.