### PR TITLE
Broaden title and define "confirmed case"

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <meta charset="utf-8">
-<title>Coronavirus US</title>
+<title>2020 Coronavirus Pandemic in the United States</title>
 <script src="https://d3js.org/d3.v5.js"></script>
 <script src="https://unpkg.com/topojson@3"></script>
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400italic,600italic,700italic,200,300,400,600,700,900">
@@ -110,7 +110,7 @@ input {
 </style>
 
 <div style="width: 100%; margin: 10px;">
-    <h1>Coronavirus Cases in the US</h1>
+    <h1>2020 Coronavirus Pandemic in the United States</h1>
     <div id="info">
       <h2 class="date"></h2>
       <div class="slider"></div>
@@ -130,6 +130,8 @@ input {
     <p><b>Source</b>: Coronavirus (COVID-19) Global Cases by the Center for Systems Science and Engineering (CSSE) at Johns Hopkins University (JHU)</p>
     <p><b>Hyperlink</b>: <a href="arcgis.com/apps/opsdashboard/index.html#/bda7594740fd40299423467b48e9ecf6">arcgis.com/apps/opsdashboard/index.html#/bda7594740fd40299423467b48e9ecf6</a></p>
     <script src="viz.js"></script>
+    <br>
+ <p>According to the <b>World Health Organization</b> (<b>WHO</b>), <i>confirmed case</i> is defined as, “a person with laboratory confirmation of COVID-19 [coronavirus disease 2019] infection, irrespective of clinical signs and symptoms.”
 </div>
 
 </html>


### PR DESCRIPTION
I changed the tab and page title from "Coronavirus US" and "Coronavirus Cases in the US," respectively, to "2020 Coronavirus Pandemic in the United States." It's important to mention the year, 2020, in which the virus first spread in the nation. I also used "Pandemic" in lieu of "Cases" because the map now features county-wide statistics for confirmed cases, deaths, and the population. Finally, below the link is the WHO's official definition of "confirmed case," meant to clarify the counts given are tests satisfactorily performed by medical laboratories.